### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ag-toolkit",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"description": "Shared library for agbd and agrb",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
# Release v0.5.0

A maintenance release focused on dependency updates and CI infrastructure improvements. No source code changes.

## 🔄 Refactoring & Maintenance

* Updated `actions/checkout` from v6.0.1 to v6.0.2 (#49, #51)
* Updated `oven-sh/setup-bun` from v2.1.0 to v2.2.0 (#60)
* Updated `actions/setup-node` from v6.1.0 to v6.3.0 (#58)

## ⬆️ Dependency Updates

* `ink` 6.6.0 → 6.8.0 (#55, #56)
* `react` 19.2.3 → 19.2.4 (#57)
* `simple-git` 3.30.0 → 3.33.0 (#53, #55, #56, #61)
* `@biomejs/biome` 2.3.11 → 2.4.8 (#55, #56, #61)
* `@types/bun` 1.3.5 → 1.3.11 (#50, #52, #54, #59, #62)
* `@types/react` 19.2.8 → 19.2.14 (#53, #55, #57, #62)
* `typescript` 5.9.3 (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)