### PR TITLE
Convert ink dependencies to peer dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,6 @@
     "": {
       "name": "ag-toolkit",
       "dependencies": {
-        "ink": "6.8.0",
-        "ink-select-input": "6.2.0",
-        "ink-spinner": "5.0.0",
-        "react": "19.2.4",
         "simple-git": "3.35.1",
       },
       "devDependencies": {
@@ -17,9 +13,19 @@
         "@types/bun": "1.3.11",
         "@types/react": "19.2.14",
         "chalk": "5.6.2",
+        "ink": "6.8.0",
+        "ink-select-input": "6.2.0",
+        "ink-spinner": "5.0.0",
         "ink-testing-library": "4.0.0",
+        "react": "19.2.4",
         "ts-node": "10.9.2",
         "typescript": "6.0.2",
+      },
+      "peerDependencies": {
+        "ink": ">=6.0.0",
+        "ink-select-input": ">=6.0.0",
+        "ink-spinner": ">=5.0.0",
+        "react": ">=18.0.0",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -33,11 +33,13 @@
 		"access": "public"
 	},
 	"dependencies": {
-		"ink": "6.8.0",
-		"ink-select-input": "6.2.0",
-		"ink-spinner": "5.0.0",
-		"react": "19.2.4",
 		"simple-git": "3.35.1"
+	},
+	"peerDependencies": {
+		"ink": ">=6.0.0",
+		"ink-select-input": ">=6.0.0",
+		"ink-spinner": ">=5.0.0",
+		"react": ">=18.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.10",
@@ -45,7 +47,11 @@
 		"@types/bun": "1.3.11",
 		"@types/react": "19.2.14",
 		"chalk": "5.6.2",
+		"ink": "6.8.0",
+		"ink-select-input": "6.2.0",
+		"ink-spinner": "5.0.0",
 		"ink-testing-library": "4.0.0",
+		"react": "19.2.4",
 		"ts-node": "10.9.2",
 		"typescript": "6.0.2"
 	}


### PR DESCRIPTION
## Summary

Convert `ink`, `ink-select-input`, `ink-spinner`, and `react` from direct dependencies to peer dependencies, while moving them to devDependencies for development and testing purposes.

## Type of Change

- [x] Refactoring (no functional changes, no api changes)

## Changes Made

- Moved `ink`, `ink-select-input`, `ink-spinner`, and `react` from `dependencies` to `peerDependencies` with relaxed version constraints (>=)
- Moved these packages to `devDependencies` to support local development and testing
- Kept `simple-git` as the only direct dependency
- Updated version constraints in peerDependencies to be more flexible (e.g., `>=6.0.0` instead of pinned versions)

## Rationale

This change allows consumers of this package to use their own versions of ink and react, reducing dependency conflicts and bundle size. The packages are still available during development and testing through devDependencies.

## Testing

- [x] I have tested this manually
- [x] All existing tests pass

The package structure has been validated and existing tests continue to pass with the new dependency configuration.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Context

This is a common pattern for UI component libraries and tools that integrate with frameworks like React, allowing for greater flexibility in dependency management for consumers.

https://claude.ai/code/session_019xqGkVDgYt4em7apk71fBE